### PR TITLE
Fix Google sign-in log message

### DIFF
--- a/flask-app/auth/auth.py
+++ b/flask-app/auth/auth.py
@@ -141,5 +141,5 @@ def google_signin():
             return jsonify({'success': False, 'error': 'Invalid token'}), 400
             
     except Exception as e:
-        print(f"Google signin error: {e}")
-        return jsonify({'success': False, 'error': 'Internal server error'}), 500 
+        print(f"Google sign-in error: {e}")
+        return jsonify({'success': False, 'error': 'Internal server error'}), 500


### PR DESCRIPTION
## Summary
- fix log message in `google_signin` exception handler

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'phoenix')*

------
https://chatgpt.com/codex/tasks/task_e_68408cc5ca188329995c82007528d405